### PR TITLE
fix: add kotlin plugin to build.gradle.kts

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -23,6 +23,8 @@ allprojects {
 
 plugins {
     id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+
 }
 
 android {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,30 +1,9 @@
 group = "com.mastertipsy.flutter_localization"
 version = "1.0-SNAPSHOT"
 
-buildscript {
-    val kotlinVersion = "2.3.20"
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("com.android.tools.build:gradle:9.0.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
-
 }
 
 android {
@@ -45,10 +24,8 @@ android {
     defaultConfig {
         minSdk = 21
     }
-}
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    kotlinOptions {
+        jvmTarget = "17"
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_localization
 description: 'Flutter Localization is a package use for in-app localization with map data. More easier and faster to implement and inspired by the flutter_localizations itself.'
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/channdara/flutter_localization
 issue_tracker: https://github.com/channdara/flutter_localization/issues
 


### PR DESCRIPTION
This pull request makes a small update to the Gradle build configuration by adding the Kotlin Android plugin.

- Build configuration:
  * Added the `org.jetbrains.kotlin.android` plugin to the `plugins` block in `android/build.gradle.kts` to enable Kotlin support for Android modules.